### PR TITLE
add keep alive to tcp socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work
+dist-newstyle


### PR DESCRIPTION
Description
This PR adds keep alive to the socket used to connect to a Faktory server. (see https://github.com/contribsys/faktory/issues/316 - the author recommends using keep alive to protect against timeouts)

Unfortunately the socket library does not have a simple way of setting socket options in it's connectTo method. So instead we're using connectFromSocket and copying some of the code from socket's connectTo method to set the keep-alive.

Testing
To test this change run the examples here: https://github.com/freckle/faktory_worker_haskell#examples
or test a producer and worker used within your application