### PR TITLE
add Show instance to WorkerId

### DIFF
--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -23,10 +23,9 @@ import Data.Aeson
 import Faktory.Connection
 import Faktory.JobOptions (JobOptions)
 import Faktory.Settings.Queue
-    ( Queue(..), namespaceQueue, queueArg, defaultQueue )
 import System.Environment (lookupEnv)
 import System.IO (hPutStrLn, stderr)
-import System.Random ( newStdGen, Random(randomRs) )
+import System.Random
 data Settings = Settings
   { settingsConnection :: ConnectionInfo
   , settingsLogDebug :: String -> IO ()

--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -9,7 +9,7 @@ module Faktory.Settings
   , namespaceQueue
   , queueArg
   , defaultQueue
-  , WorkerId
+  , WorkerId(..)
   , randomWorkerId
 
   -- * Re-exports
@@ -23,10 +23,10 @@ import Data.Aeson
 import Faktory.Connection
 import Faktory.JobOptions (JobOptions)
 import Faktory.Settings.Queue
+    ( Queue(..), namespaceQueue, queueArg, defaultQueue )
 import System.Environment (lookupEnv)
 import System.IO (hPutStrLn, stderr)
-import System.Random
-
+import System.Random ( newStdGen, Random(randomRs) )
 data Settings = Settings
   { settingsConnection :: ConnectionInfo
   , settingsLogDebug :: String -> IO ()

--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -26,6 +26,7 @@ import Faktory.Settings.Queue
 import System.Environment (lookupEnv)
 import System.IO (hPutStrLn, stderr)
 import System.Random
+
 data Settings = Settings
   { settingsConnection :: ConnectionInfo
   , settingsLogDebug :: String -> IO ()

--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -9,7 +9,7 @@ module Faktory.Settings
   , namespaceQueue
   , queueArg
   , defaultQueue
-  , WorkerId(..)
+  , WorkerId
   , randomWorkerId
 
   -- * Re-exports
@@ -74,7 +74,10 @@ envWorkerSettings = do
     }
 
 newtype WorkerId = WorkerId String
-  deriving newtype (FromJSON, ToJSON)
+  deriving newtype (FromJSON, ToJSON, Show)
+
+-- instance Show WorkerId where
+--   show (WorkerId wid) = wid
 
 randomWorkerId :: IO WorkerId
 randomWorkerId = WorkerId . take 8 . randomRs ('a', 'z') <$> newStdGen

--- a/library/Faktory/Settings.hs
+++ b/library/Faktory/Settings.hs
@@ -74,10 +74,10 @@ envWorkerSettings = do
     }
 
 newtype WorkerId = WorkerId String
-  deriving newtype (FromJSON, ToJSON, Show)
+  deriving newtype (FromJSON, ToJSON)
 
--- instance Show WorkerId where
---   show (WorkerId wid) = wid
+instance Show WorkerId where
+  show (WorkerId wid) = wid
 
 randomWorkerId :: IO WorkerId
 randomWorkerId = WorkerId . take 8 . randomRs ('a', 'z') <$> newStdGen

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,4 @@ resolver: lts-19.1
 
 ghc-options:
   "$locals": -fwrite-ide-info
+system-ghc: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,3 @@ resolver: lts-19.1
 
 ghc-options:
   "$locals": -fwrite-ide-info
-system-ghc: true


### PR DESCRIPTION
This PR exports the `WorkerId` constructor. The reasoning for this is it allows us to extract the string value so we can actually use and report the worker id.
