### PR TITLE
Add state to worker

### DIFF
--- a/faktory.cabal
+++ b/faktory.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3f510fab784e669ccb4ccbeb24aacaa7c33b3008686c4e68207214feceea5d6e
+-- hash: f567ab5ccc3a99fa5ba5081f0d12a87857fafaf84a6dc9eb84098721ae66b6ae
 
 name:           faktory
 version:        1.1.2.2
@@ -91,6 +91,7 @@ library
       GeneralizedNewtypeDeriving
       LambdaCase
       MultiParamTypeClasses
+      NamedFieldPuns
       NoImplicitPrelude
       NoMonomorphismRestriction
       OverloadedStrings
@@ -148,6 +149,7 @@ executable faktory-example-consumer
       GeneralizedNewtypeDeriving
       LambdaCase
       MultiParamTypeClasses
+      NamedFieldPuns
       NoImplicitPrelude
       NoMonomorphismRestriction
       OverloadedStrings
@@ -190,6 +192,7 @@ executable faktory-example-producer
       GeneralizedNewtypeDeriving
       LambdaCase
       MultiParamTypeClasses
+      NamedFieldPuns
       NoImplicitPrelude
       NoMonomorphismRestriction
       OverloadedStrings
@@ -240,6 +243,7 @@ test-suite hspec
       GeneralizedNewtypeDeriving
       LambdaCase
       MultiParamTypeClasses
+      NamedFieldPuns
       NoImplicitPrelude
       NoMonomorphismRestriction
       OverloadedStrings
@@ -287,6 +291,7 @@ test-suite readme
       GeneralizedNewtypeDeriving
       LambdaCase
       MultiParamTypeClasses
+      NamedFieldPuns
       NoImplicitPrelude
       NoMonomorphismRestriction
       OverloadedStrings

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -89,10 +89,10 @@ withRunWorker ::
   (HasCallStack, FromJSON args)
   =>  Settings
   -> WorkerSettings
-  -> (Job args -> IO ())
   -> (WorkerConfig -> IO a)
+  -> (Job args -> IO ())
   -> IO ()
-withRunWorker settings workerSettings handler action =
+withRunWorker settings workerSettings action handler =
   bracket
     (configureWorker settings workerSettings)
     stopWorker

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -5,7 +5,7 @@
 --
 module Faktory.Worker (
   WorkerHalt (..),
-  WorkerConfig (isQuieted, client, workerId, workerSettings, settings),
+  WorkerConfig (..),
   runWorker,
   runWorkerEnv,
   withRunWorker,
@@ -87,7 +87,7 @@ untilM_ predicate action = do
     )
 
 -- | Creates a new faktory worker, @'action'@ is ran with @'WorkerConfig'@ before
--- polling begins. Jobs received are passed to @'handler'. The worker's
+-- polling begins. Jobs received are passed to @'handler'@. The worker's
 -- connection is closed when job processing ends.
 withRunWorker ::
   (HasCallStack, FromJSON args)

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -81,7 +81,7 @@ forkWithThrowToParent :: Worker () -> Worker ThreadId
 forkWithThrowToParent action = do
   parent <- liftIO myThreadId
   workerConfig <- ask
-  liftIO $ forkIO $ (flip runReaderT workerConfig. runWorkerM $ action) `catchAny` \err -> throwTo parent err
+  liftIO $ forkIO $ (flip runReaderT workerConfig . runWorkerM $ action) `catchAny` \err -> throwTo parent err
 
 createWorker
   :: HasCallStack
@@ -110,11 +110,12 @@ startWorker
   -> Worker ()
 startWorker f = do
   config <- ask
-  liftIO $ flip runReaderT config . runWorkerM $ do
-    beatThreadId <- forkWithThrowToParent $ forever heartBeat
-    untilM_ shouldRunWorker (processorLoop f)
-      `catch` (\(_ex :: WorkerHalt) -> pure ())
-      `finally` killWorker beatThreadId
+  liftIO
+    $ flip runReaderT config . runWorkerM $ do
+      beatThreadId <- forkWithThrowToParent $ forever heartBeat
+      untilM_ shouldRunWorker (processorLoop f)
+        `catch` (\(_ex :: WorkerHalt) -> pure ())
+        `finally` killWorker beatThreadId
 
 shouldRunWorker :: Worker Bool
 shouldRunWorker = do

--- a/package.yaml
+++ b/package.yaml
@@ -80,6 +80,7 @@ default-extensions:
   - GeneralizedNewtypeDeriving
   - LambdaCase
   - MultiParamTypeClasses
+  - NamedFieldPuns
   - NoImplicitPrelude
   - NoMonomorphismRestriction
   - OverloadedStrings


### PR DESCRIPTION
This PR refactors the worker to use state. There are two main reasons do add state.

The first is that workers do not properly handle a `quiet` response from the faktory serve from a heartbeat request. [See here for how worker heartbeats](https://github.com/contribsys/faktory/wiki/Worker-Lifecycle#heartbeat). (this will be handled in a separate PR)

The second reason is to be able to support graceful shutdown. We want the worker to stop fetching tasks when the worker is being shutdown. 

The implementation now includes: creating a worker, starting a worker and quieting a worker - these functions are exported so they can be used to handle the second case above. 

I've also refactored most of the functions in this module to use `WorkerConfig` to avoid passing parameters around. In order to support backwards compatibility `runWorker` still functions as it previously did, but does not support quieting a worker.

## Testing

