### PR TITLE
refactor worker to enable returning execution to consumers

### DIFF
--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -5,7 +5,7 @@
 --
 module Faktory.Worker (
   WorkerHalt (..),
-  Worker (config),
+  Worker (config, tid),
   WorkerConfig (workerId),
   runWorker,
   runWorkerEnv,

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -96,7 +96,7 @@ untilM_ predicate action = do
         untilM_ predicate action
     )
 
--- | Forks a new faktory worker, continuously polls the faktory server for
+-- | Forks a new faktory worker and continuously polls the faktory server for
 -- jobs which are passed to @'handler'@. The client is closed when the forked
 -- thread ends.
 startWorker
@@ -121,7 +121,7 @@ startWorker settings workerSettings handler = do
                   (untilM_ (liftIO $ readTVarIO isQuieted) (processorLoop handler))
                   (\(_ex :: WorkerHalt) -> pure ())
             )
-            $ killThread beatThreadId
+            (killThread beatThreadId)
       )
       ( \e -> do
           closeClient client
@@ -212,4 +212,4 @@ failJob job message = do
   liftIO $ commandOK client "FAIL" [encode $ FailPayload message "" (jobJid job) []]
 
 workerId :: Worker -> WorkerId
-workerId Worker{config=WorkerConfig{wid}} = wid
+workerId Worker{config = WorkerConfig{wid}} = wid

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -62,7 +62,7 @@ instance ToJSON AckPayload where
   toJSON = genericToJSON $ aesonPrefix snakeCase
   toEncoding = genericToEncoding $ aesonPrefix snakeCase
 
-newtype WorkerM a = WorkerReader
+newtype WorkerM a = WorkerM
   { runWorkerM :: ReaderT Worker IO a
   }
   deriving newtype (Functor, Applicative, Monad, MonadReader Worker, MonadIO, MonadThrow, MonadCatch, MonadMask)

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -10,7 +10,7 @@ module Faktory.Worker (
   runWorker,
   runWorkerEnv,
   startWorker,
-  untilWorkerDone,
+  waitUntilDone,
   quietWorker,
   jobArg,
 ) where
@@ -137,7 +137,7 @@ runWorker
   -> IO ()
 runWorker settings workerSettings handler = do
   (_, worker) <- startWorker settings workerSettings handler
-  untilWorkerDone worker
+  waitUntilDone worker
 
 runWorkerEnv :: FromJSON args => (Job args -> IO ()) -> IO ()
 runWorkerEnv f = do
@@ -146,8 +146,8 @@ runWorkerEnv f = do
   runWorker settings workerSettings f
 
 -- | Blocks until the worker thread has completed.
-untilWorkerDone :: Worker -> IO ()
-untilWorkerDone Worker{isDone} = takeMVar isDone
+waitUntilDone :: Worker -> IO ()
+waitUntilDone Worker{isDone} = takeMVar isDone
 
 -- | Quiet's a worker so that it no longer polls for jobs.
 quietWorker :: Worker -> IO ()

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -16,7 +16,7 @@ module Faktory.Worker (
 ) where
 
 import Faktory.Prelude
-import Control.Concurrent (MVar, ThreadId, forkFinally, killThread, newEmptyMVar, putMVar, takeMVar, myThreadId)
+import Control.Concurrent (MVar, ThreadId, forkFinally, killThread, myThreadId, newEmptyMVar, putMVar, takeMVar)
 import Control.Monad.Reader (MonadIO (liftIO), MonadReader (ask), ReaderT (runReaderT))
 import Data.Aeson
 import Data.Aeson.Casing

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -89,13 +89,13 @@ untilM_ predicate action = do
         untilM_ predicate action
     )
 
--- | Returns the workerId associated with a Worker.
+-- | Returns the @'WorkerId' associated with a @'Worker'.
 workerID :: Worker -> WorkerId
 workerID Worker{workerId} = workerId
 
 -- | Forks a new faktory worker, continuously polls the faktory server for
--- jobs which are passed to @'handler'@. Client is closed when the forked
--- thread is done.
+-- jobs which are passed to @'handler'@. The client is closed when the forked
+-- thread ends.
 startWorker
   :: (HasCallStack, FromJSON args)
   => Settings
@@ -127,10 +127,6 @@ startWorker settings workerSettings handler = do
       )
   pure (tid, worker)
 
--- | Blocks the thread until the worker thread has completed.
-untilWorkerDone :: Worker -> IO ()
-untilWorkerDone Worker{isDone} = takeMVar isDone
-
 -- | Creates a new faktory worker, continuously polls the faktory server for
 --- jobs which are passed to @'handler'@.
 runWorker
@@ -148,6 +144,10 @@ runWorkerEnv f = do
   settings <- envSettings
   workerSettings <- envWorkerSettings
   runWorker settings workerSettings f
+
+-- | Blocks until the worker thread has completed.
+untilWorkerDone :: Worker -> IO ()
+untilWorkerDone Worker{isDone} = takeMVar isDone
 
 -- | Quiet's a worker so that it no longer polls for jobs.
 quietWorker :: Worker -> IO ()

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -5,7 +5,7 @@
 --
 module Faktory.Worker (
   WorkerHalt (..),
-  Worker (config, tid),
+  Worker (tid),
   jobArg,
   quietWorker,
   runWorker,

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -5,8 +5,7 @@
 --
 module Faktory.Worker (
   WorkerHalt (..),
-  Worker,
-  workerID,
+  Worker (workerId),
   runWorker,
   runWorkerEnv,
   startWorker,
@@ -88,10 +87,6 @@ untilM_ predicate action = do
         void action
         untilM_ predicate action
     )
-
--- | Returns the @'WorkerId' associated with a @'Worker'.
-workerID :: Worker -> WorkerId
-workerID Worker{workerId} = workerId
 
 -- | Forks a new faktory worker, continuously polls the faktory server for
 -- jobs which are passed to @'handler'@. The client is closed when the forked

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -16,7 +16,7 @@ module Faktory.Worker (
 ) where
 
 import Faktory.Prelude
-import Control.Concurrent (MVar, forkFinally, killThread, newEmptyMVar, putMVar, takeMVar, ThreadId)
+import Control.Concurrent (MVar, ThreadId, forkFinally, killThread, newEmptyMVar, putMVar, takeMVar)
 import Control.Monad.Reader (MonadIO (liftIO), MonadReader (ask), ReaderT (runReaderT))
 import Data.Aeson
 import Data.Aeson.Casing

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -114,8 +114,7 @@ startWorker settings workerSettings handler = do
           beatThreadId <- forkIOWithThrowToParent $ forever $ heartBeat worker
           finally
             ( flip runReaderT worker . runWorkerM $
-                untilM_ shouldStopWorker (processorLoop handler)
-                  `catch` (\(_ex :: WorkerHalt) -> pure ())
+                catch (untilM_ shouldStopWorker (processorLoop handler)) (\(_ex :: WorkerHalt) -> pure ())
             )
             $ killThread beatThreadId
       )


### PR DESCRIPTION
## Description

This PR is intended to clean and simplify the worker design. We are removing the ability to run an action before starting a worker in favor of returning execution to the consumer. We are also exposing a way to block until the worker thread is done.

Here is an example:

```
  (tid, worker)  <- startWorker faktorySettings workerSettings processJob
  putStrLn $ "Worker is consuming jobs in thread: " <> show tid
  waitUntilDone worker
  putStrLn "Worker is done!"
```
## Testing plan

1. Run this command to apply a patch to the cleaned branch:
```
cat << EOF | git apply
diff --git a/examples/consumer/Main.hs b/examples/consumer/Main.hs
index c89484d..300bcde 100644
--- a/examples/consumer/Main.hs
+++ b/examples/consumer/Main.hs
@@ -6,6 +6,8 @@ import Control.Exception.Safe
 import Data.Aeson
 import Faktory.Worker
 import GHC.Generics
+import Faktory.Worker
+import Faktory.Settings
 
 -- | Must match examples/producer
 newtype Job = Job { jobMessage :: String }
@@ -15,9 +17,13 @@ newtype Job = Job { jobMessage :: String }
 main :: IO ()
 main = do
   putStrLn "Starting consumer loop"
-  runWorkerEnv $ \job -> do
+  settings <- envSettings
+  workerSettings <- envWorkerSettings
+  worker <- startWorker settings workerSettings $ \job -> do
     let message = jobMessage $ jobArg job
 
     if message == "BOOM"
       then throwString "Producer exception: BOOM"
       else putStrLn message
+  waitUntilDone worker
+  putStrLn "Worker is done!"
diff --git a/stack.yaml b/stack.yaml
index cb1396f..9700a19 100644
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,7 @@ resolver: lts-19.1
 
 ghc-options:
   "\$locals": -fwrite-ide-info
+
+extra-deps:
+  - git: https://github.com/fossas/faktory_worker_haskell
+    commit: 1ffaa7da1cd14c487d939ba67957f1cd3e9ca42e

EOF
```
 2. ensure faktory is running on localhost and port 7419
 3. Run `cabal run faktory-example-producer testing` 3 times
 4. Run `cabal run faktory-example-consumer`
 5. You see `testing` printed out 3 times
 6. The program should not exit and you should never see Worker is done!

### Testing quieting a worker

1. Apply this patch to the cleaned branch:
```
cat << EOF | git apply
diff --git a/examples/consumer/Main.hs b/examples/consumer/Main.hs
index c89484d..5d73339 100644
--- a/examples/consumer/Main.hs
+++ b/examples/consumer/Main.hs
@@ -2,10 +2,13 @@ module Main (main) where
 
 import Prelude
 
+import Control.Concurrent
 import Control.Exception.Safe
 import Data.Aeson
 import Faktory.Worker
 import GHC.Generics
+import Faktory.Settings
+import Faktory.Prelude
 
 -- | Must match examples/producer
 newtype Job = Job { jobMessage :: String }
@@ -15,9 +18,16 @@ newtype Job = Job { jobMessage :: String }
 main :: IO ()
 main = do
   putStrLn "Starting consumer loop"
-  runWorkerEnv $ \job -> do
+  settings <- envSettings
+  workerSettings <- envWorkerSettings
+  worker<- startWorker settings workerSettings $ \job -> do
     let message = jobMessage $ jobArg job
 
     if message == "BOOM"
       then throwString "Producer exception: BOOM"
       else putStrLn message
+  _ <- forkIO $ do
+    threadDelaySeconds 5
+    quietWorker worker
+  waitUntilDone worker
+  putStrLn "Worker is done!"
diff --git a/stack.yaml b/stack.yaml
index cb1396f..9700a19 100644
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,7 @@ resolver: lts-19.1
 
 ghc-options:
   "\$locals": -fwrite-ide-info
+
+extra-deps:
+  - git: https://github.com/fossas/faktory_worker_haskell
+    commit: 1ffaa7da1cd14c487d939ba67957f1cd3e9ca42e
EOF
```
 2. ensure faktory is running on localhost and port 7419
 3. Run `cabal run faktory-example-producer testing` 1 time
 4. Run `cabal run faktory-example-consumer`
 5. You see `testing` printed out 
 6. After 5 seconds you see `Worker is done!` and the program exits


### Testing WorkerHalt error
1. Apply this patch to the cleaned branch:
```
cat << EOF | git apply
diff --git a/examples/consumer/Main.hs b/examples/consumer/Main.hs
index c89484d..b8238a0 100644
--- a/examples/consumer/Main.hs
+++ b/examples/consumer/Main.hs
@@ -6,6 +6,8 @@ import Control.Exception.Safe
 import Data.Aeson
 import Faktory.Worker
 import GHC.Generics
+import Faktory.Settings
+import Faktory.Prelude
 
 -- | Must match examples/producer
 newtype Job = Job { jobMessage :: String }
@@ -15,9 +17,13 @@ newtype Job = Job { jobMessage :: String }
 main :: IO ()
 main = do
   putStrLn "Starting consumer loop"
-  runWorkerEnv $ \job -> do
+  settings <- envSettings
+  workerSettings <- envWorkerSettings
+  worker <- startWorker settings workerSettings $ \job -> do
     let message = jobMessage $ jobArg job
-
+    _ <- throwIO WorkerHalt
     if message == "BOOM"
       then throwString "Producer exception: BOOM"
       else putStrLn message
+  waitUntilDone worker
+  putStrLn "Worker is done!"
diff --git a/stack.yaml b/stack.yaml
index cb1396f..9700a19 100644
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,7 @@ resolver: lts-19.1
 
 ghc-options:
   "\$locals": -fwrite-ide-info
+
+extra-deps:
+  - git: https://github.com/fossas/faktory_worker_haskell
+    commit: 1ffaa7da1cd14c487d939ba67957f1cd3e9ca42e
EOF
```
2. ensure faktory is running on localhost and port 7419
3. Run `cabal run faktory-example-producer testing` 1 time
4. Run `cabal run faktory-example-consumer`
5. You see `Worker is done!` and the program exits
6. Check the faktory UI (https://localhost:7420) and the job is shown as busy (this is the same behavior as the faktory_worker_haskell library upstream)