### PR TITLE
Changes FaktoryException's Show to tag that it's a FaktoryException

### DIFF
--- a/library/Faktory/Prelude.hs
+++ b/library/Faktory/Prelude.hs
@@ -16,7 +16,7 @@ import GHC.Stack.Types (HasCallStack)
 import GHC.Stack (callStack)
 
 newtype FaktoryException = FaktoryException StringException
-  deriving newtype (Show)
+  deriving stock (Show)
   deriving anyclass (Exception)
 
 throwFaktoryException :: (MonadThrow m, HasCallStack) => String -> m a


### PR DESCRIPTION
Previously this type was using `newtype` deriving which just passes through the calls and so the `Show` instance was just printing the internals which lead me to mistake it for a StringException itself.

This will use stock `Show` which will be `show (FaktoryException e) = "FaktoryException " <> show e`.  That gives it a nice little prefix.