### PR TITLE
[PLAT-354] use local hostname instead of connection hostname for workername

### DIFF
--- a/faktory.cabal
+++ b/faktory.cabal
@@ -110,6 +110,7 @@ library
     , connection
     , cryptonite
     , errors
+    , hostname
     , megaparsec
     , memory
     , mtl

--- a/library/Faktory/Client.hs
+++ b/library/Faktory/Client.hs
@@ -29,6 +29,7 @@ import Faktory.Settings
 import GHC.Stack
 import Network.Connection
 import Network.Socket (HostName)
+import Network.HostName (getHostName)
 import System.Posix.Process (getProcessID)
 
 data Client = Client
@@ -102,8 +103,9 @@ newClient settings@Settings {..} mWorkerId =
       mPassword = connectionInfoPassword settingsConnection
       mHashedPassword = hashPassword <$> hiNonce <*> hiIterations <*> mPassword
 
+    hostname <- getHostName
     helloPayload <-
-      HelloPayload mWorkerId (show . fst $ connectionID conn)
+      HelloPayload mWorkerId hostname
       <$> (toInteger <$> getProcessID)
       <*> pure ["haskell"]
       <*> pure expectedProtocolVersion


### PR DESCRIPTION
## Description

This PR changes the hello payload within the faktory worker to use the local host name instead of the connection hostname.

## Testing Plan
- run the faktory-example-consumer and then navigate to the faktory UI you should see the worker name is your local hostname

![image](https://user-images.githubusercontent.com/15069040/197032274-62876483-26d2-46e4-8925-5478cbcaf792.png)
