### PR TITLE
Fix hang on close exception

### DIFF
--- a/faktory.cabal
+++ b/faktory.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f567ab5ccc3a99fa5ba5081f0d12a87857fafaf84a6dc9eb84098721ae66b6ae
+-- hash: c448d243eb605104c31c0c4489c430a94ba9c528d32aaec36678b544007423b0
 
 name:           faktory
 version:        1.1.2.2
@@ -122,11 +122,11 @@ library
     , time
     , unix
     , unordered-containers
+  default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
-  default-language: Haskell2010
 
 executable faktory-example-consumer
   main-is: Main.hs
@@ -165,11 +165,11 @@ executable faktory-example-consumer
     , base ==4.*
     , faktory
     , safe-exceptions
+  default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
-  default-language: Haskell2010
 
 executable faktory-example-producer
   main-is: Main.hs
@@ -208,11 +208,11 @@ executable faktory-example-producer
     , base ==4.*
     , faktory
     , safe-exceptions
+  default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
-  default-language: Haskell2010
 
 test-suite hspec
   type: exitcode-stdio-1.0
@@ -263,11 +263,11 @@ test-suite hspec
     , hspec
     , mtl
     , time
+  default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
-  default-language: Haskell2010
 
 test-suite readme
   type: exitcode-stdio-1.0
@@ -307,8 +307,8 @@ test-suite readme
     , base ==4.*
     , faktory
     , markdown-unlit
+  default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
-  default-language: Haskell2010

--- a/faktory.cabal
+++ b/faktory.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c448d243eb605104c31c0c4489c430a94ba9c528d32aaec36678b544007423b0
+-- hash: f567ab5ccc3a99fa5ba5081f0d12a87857fafaf84a6dc9eb84098721ae66b6ae
 
 name:           faktory
 version:        1.1.2.2
@@ -122,11 +122,11 @@ library
     , time
     , unix
     , unordered-containers
-  default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
+  default-language: Haskell2010
 
 executable faktory-example-consumer
   main-is: Main.hs
@@ -165,11 +165,11 @@ executable faktory-example-consumer
     , base ==4.*
     , faktory
     , safe-exceptions
-  default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
+  default-language: Haskell2010
 
 executable faktory-example-producer
   main-is: Main.hs
@@ -208,11 +208,11 @@ executable faktory-example-producer
     , base ==4.*
     , faktory
     , safe-exceptions
-  default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
+  default-language: Haskell2010
 
 test-suite hspec
   type: exitcode-stdio-1.0
@@ -263,11 +263,11 @@ test-suite hspec
     , hspec
     , mtl
     , time
-  default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
+  default-language: Haskell2010
 
 test-suite readme
   type: exitcode-stdio-1.0
@@ -307,8 +307,8 @@ test-suite readme
     , base ==4.*
     , faktory
     , markdown-unlit
-  default-language: Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
+  default-language: Haskell2010

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -138,8 +138,9 @@ startWorker settings workerSettings handler = do
         putMVar isDone ()
       )
         `catchAny` \cleanupEx -> do
-          settingsLogError settings $ "Exception during worker cleanup: " <> displayException cleanupEx
+          -- Throw first in case the logging ever throws an error.
           throwTo parentThreadId cleanupEx
+          settingsLogError settings $ "Exception during worker cleanup: " <> displayException cleanupEx
 
 -- | Creates a new faktory worker, continuously polls the faktory server for
 --- jobs which are passed to @'handler'@.

--- a/library/Faktory/Worker.hs
+++ b/library/Faktory/Worker.hs
@@ -123,17 +123,23 @@ startWorker settings workerSettings handler = do
             )
             (killThread beatThreadId)
       )
-      ( \e -> do
-          closeClient client
-          putMVar isDone ()
-          case e of
-            Left err ->
-              case fromException err of
-                Just (_ :: WorkerHalt) -> pure ()
-                Nothing -> throwTo parentThreadId err
-            Right _ -> pure ()
-      )
+      (workerCleanup client isDone parentThreadId)
   pure Worker{tid, config, isDone, isQuieted}
+  where
+    workerCleanup client isDone parentThreadId e =
+      ( do
+        closeClient client
+        case e of
+          Left err ->
+            case fromException err of
+              Just (_ :: WorkerHalt) -> pure ()
+              Nothing -> throw err
+          Right () -> pure ()
+        putMVar isDone ()
+      )
+        `catchAny` \cleanupEx -> do
+          settingsLogError settings $ "Exception during worker cleanup: " <> displayException cleanupEx
+          throwTo parentThreadId cleanupEx
 
 -- | Creates a new faktory worker, continuously polls the faktory server for
 --- jobs which are passed to @'handler'@.


### PR DESCRIPTION
[PLAT-404](https://fossa.atlassian.net/browse/PLAT-404)

There is a situation where the client will hang.

The first thing that worker cleanup does is `closeClient client`.  If the `closeClient` function throws an exception, such as if the socket has already been cleaned up by the OS after a disconnect, then we will never get to `putMVar` or `throwToParent`.  Neither mechanism for signalling the parent thread will be triggered and the parent may be deadlocked on `waitUntilDone`.

This PR reorganizes the clean up logic so that either the parent will be signaled or it will receive an exception, but not both and that all code paths do one of the two.